### PR TITLE
[Fix #9] Prepend the Ruby binary to a command line

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <idea-plugin version="2">
     <id>io.github.sirlantis.rubymine.rubocop</id>
     <name>RuboCop</name>
-    <version>2.0.0.rc1</version>
+    <version>2.0.0.rc2</version>
     <vendor email="marceljackwerth@gmail.com" url="http://twitter.com/sirlantis">Marcel Jackwerth</vendor>
 
     <description><![CDATA[
@@ -9,6 +9,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <p>2.0.0.rc2 Fix the (command line) execution on Windows.</p>
         <p>2.0.0 Depend on Ruby plugin for CommandLine execution.</p>
         <p>1.0.1 Fix compatibility issues with rbenv.</p>
         <p>1.0.0 Fix compatibility issues with RVM.</p>

--- a/src/io/github/sirlantis/rubymine/rubocop/RubocopTask.kt
+++ b/src/io/github/sirlantis/rubymine/rubocop/RubocopTask.kt
@@ -164,7 +164,10 @@ class RubocopTask(val module: Module, val paths: List<String>) : Task.Background
             commandLineList.addAll(0, linkedListOf(bundleCommand.getCanonicalPath(), "exec"))
         }
 
-        commandLineList.add(0, "ruby")
+        // prepend ruby binary to the command
+        val rubyInterpreterExecutable = sdk.getHomePath();
+        commandLineList.add(0, rubyInterpreterExecutable)
+
         val command = commandLineList.removeFirst()
         val args = commandLineList.copyToArray()
 

--- a/src/io/github/sirlantis/rubymine/rubocop/RubocopTask.kt
+++ b/src/io/github/sirlantis/rubymine/rubocop/RubocopTask.kt
@@ -164,6 +164,7 @@ class RubocopTask(val module: Module, val paths: List<String>) : Task.Background
             commandLineList.addAll(0, linkedListOf(bundleCommand.getCanonicalPath(), "exec"))
         }
 
+        commandLineList.add(0, "ruby")
         val command = commandLineList.removeFirst()
         val args = commandLineList.copyToArray()
 


### PR DESCRIPTION
Prepend the Ruby binary to the generated command line for fixing execution problems on Windows.